### PR TITLE
Add test for MACAddressField basic case, + tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pyo
+*.swp
 build
 ctags
 cscope.*
@@ -7,3 +8,5 @@ cscope.*
 /.pydevproject
 /dist
 /django_macaddress.egg-info
+.eggs
+.tox/

--- a/macaddress/__init__.py
+++ b/macaddress/__init__.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from netaddr import mac_unix
+from netaddr import mac_unix, mac_eui48
 
 import importlib
 import warnings
@@ -10,9 +10,9 @@ class mac_linux(mac_unix):
     word_fmt = '%.2X'
 
 def default_dialect(eui_obj=None):
-    # Check to see if a default dialect class has been specified in settings, 
-    # using 'module.dialect_cls' string and use importlib and getattr to retrieve dialect class. 'module' is the module and 
-    # 'dialect_cls' is the class name of the custom dialect. The dialect must either be defined or imported by the module's 
+    # Check to see if a default dialect class has been specified in settings,
+    # using 'module.dialect_cls' string and use importlib and getattr to retrieve dialect class. 'module' is the module and
+    # 'dialect_cls' is the class name of the custom dialect. The dialect must either be defined or imported by the module's
     # __init__.py if the module is a package.
     from .fields import MACAddressField # Remove import at v1.4
     if hasattr(settings, 'MACADDRESS_DEFAULT_DIALECT') and not MACAddressField.dialect:
@@ -34,9 +34,9 @@ def default_dialect(eui_obj=None):
             return mac_linux
 
 def format_mac(eui_obj, dialect):
-    # Format a EUI instance as a string using the supplied dialect class, allowing custom string classes by 
+    # Format a EUI instance as a string using the supplied dialect class, allowing custom string classes by
     # passing directly or as a string, a la 'module.dialect_cls', where 'module' is the module and 'dialect_cls'
-    # is the class name of the custom dialect. The dialect must either be defined or imported by the module's __init__.py if 
+    # is the class name of the custom dialect. The dialect must either be defined or imported by the module's __init__.py if
     # the module is a package.
     if not isinstance(dialect, mac_eui48):
         if isinstance(dialect, str):

--- a/macaddress/tests/models.py
+++ b/macaddress/tests/models.py
@@ -2,7 +2,7 @@
 A model for testing
 """
 from django.db import models
-from fields import MACAddressField
+from macaddress.fields import MACAddressField
 
 class NetworkThingy(models.Model):
     mac = MACAddressField()

--- a/macaddress/tests/test_fields.py
+++ b/macaddress/tests/test_fields.py
@@ -1,0 +1,30 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from netaddr.core import AddrFormatError
+
+from .models import NetworkThingy
+
+
+class MACAddressFieldTestCase(TestCase):
+
+    def setUp(self):
+        self.model = NetworkThingy
+
+    def test_insert_valid_macaddress(self):
+        mac_example = '00:11:22:33:44:AA'
+        x = self.model()
+        x.mac = mac_example
+        x.save()
+        self.assertEquals(x.mac, mac_example)
+        self.assertEquals(NetworkThingy.objects.get(mac=mac_example).mac,
+                mac_example)
+        self.assertEquals(NetworkThingy.objects.all().count(), 1)
+
+    def test_insert_invalid_macaddress(self):
+        invalid_mac = 'XX'
+        x = self.model()
+        with self.assertRaises(ValidationError):
+            x.mac = invalid_mac
+            x.save()
+        self.assertEquals(NetworkThingy.objects.all().count(), 0)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+coverage
+coveralls
+mock>=1.0.1
+nose>=1.3.0
+django-nose>=1.2
+flake8>=2.1.0
+tox>=1.7.0

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+import sys
+
+import django
+from django.conf import settings
+
+
+if not settings.configured:
+    settings.configure(
+        DATABASES={
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': ':memory:',
+            }
+        },
+        INSTALLED_APPS=(
+            'django.contrib.auth',
+            'django.contrib.contenttypes',
+            'django.contrib.sessions',
+            'django.contrib.admin',
+            'macaddress.tests',
+            'macaddress',
+        ),
+        SITE_ID=1,
+        SECRET_KEY='this-is-just-for-tests-so-not-that-secret',
+        MIDDLEWARE_CLASSES=(),
+    )
+
+
+from django.test.utils import get_runner
+
+
+def runtests():
+    if hasattr(django, 'setup'):
+        django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner(verbosity=1, interactive=True, failfast=False)
+    apps = ['macaddress', ]
+    failures = test_runner.run_tests(apps)
+    sys.exit(failures)
+
+
+if __name__ == '__main__':
+    runtests()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     packages = ['macaddress'],
     install_requires = ['netaddr'],
     tests_require = ['django'],
+    test_suite="runtests.runtests",
 
     classifiers = [
         'Development Status :: 5 - Production/Stable',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+downloadcache = {toxworkdir}/_download/
+envlist = 
+  {py27}-{django16,django17,django18}
+
+[testenv]
+basepython =
+       py27: python2.7
+
+; py34: python3.4
+deps = -r{toxinidir}/requirements-test.txt
+       django16: django==1.6
+       django17: django==1.7
+       django18: django==1.8
+
+commands = {envpython} runtests.py


### PR DESCRIPTION
Hello guys,

This is a WIP version for add tests to django-macaddress .. I have to figure out why are not running in python3.4 I think it can be merged now in order to add travis support later.

In the meanwhile I'll be figuring out what is the issue with the python 3.4 version and then add it back to tox.ini

Regards