### PR TITLE
Fix NameError when executing `macaddress.format_mac()`

### DIFF
--- a/macaddress/__init__.py
+++ b/macaddress/__init__.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from netaddr import mac_unix
+from netaddr import mac_eui48, mac_unix
 
 import importlib
 import warnings

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = "1.3.0"
+version = "1.3.1"
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()


### PR DESCRIPTION
- Tested with netaddr 0.7.15