### PR TITLE
Add support for Python 3.12

### DIFF
--- a/macaddress/__init__.py
+++ b/macaddress/__init__.py
@@ -46,13 +46,26 @@ def format_mac(eui_obj, dialect):
     return str(eui_obj)
 
 
-from pkg_resources import get_distribution, DistributionNotFound
-import os.path
+__version__ = 'Please install this project with setup.py'  # Fallback
+_pkg_name = 'django-macaddress'
 
 try:
-    _dist = get_distribution('django-macaddress')
-except DistributionNotFound:
-    __version__ = 'Please install this project with setup.py'
+    from pkg_resources import get_distribution, DistributionNotFound
+except ImportError:
+    # Python 3.12+
+    from importlib.metadata import version, PackageNotFoundError
+
+    try:
+        __version__ = version(_pkg_name)
+    except PackageNotFoundError:
+        pass
 else:
-    __version__ = _dist.version
-VERSION = __version__   # synonym
+    # Python 3.8 - 3.11
+    try:
+        _dist = get_distribution(_pkg_name)
+    except DistributionNotFound:
+        pass
+    else:
+        __version__ = _dist.version
+
+VERSION = __version__  # synonym

--- a/macaddress/tests/test_fields.py
+++ b/macaddress/tests/test_fields.py
@@ -13,9 +13,9 @@ class MACAddressFieldTestCase(TestCase):
         x = NetworkThingy(mac=mac_example)
         x.save()
         qm = NetworkThingy.objects
-        self.assertEquals(x.mac, mac_example)
-        self.assertEquals(qm.get(mac=mac_example).mac, mac_example)
-        self.assertEquals(qm.all().count(), 1)
+        self.assertEqual(x.mac, mac_example)
+        self.assertEqual(qm.get(mac=mac_example).mac, mac_example)
+        self.assertEqual(qm.all().count(), 1)
 
     def test_insert_invalid_macaddress(self):
         invalid_mac = 'XX'
@@ -24,4 +24,4 @@ class MACAddressFieldTestCase(TestCase):
             with self.assertRaises(ValidationError):
                 x.mac = invalid_mac
                 x.save()
-        self.assertEquals(NetworkThingy.objects.all().count(), 0)
+        self.assertEqual(NetworkThingy.objects.all().count(), 0)


### PR DESCRIPTION
This closes #49.

It does so without making any changes irrelevant with Python 3.12 compatibility. The approach is conservative, so as not to break backwards compatibility.

Let me know if there is anything I am missing here.